### PR TITLE
Fix useSearchParams Suspense boundary warnings

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import * as Dialog from "@radix-ui/react-dialog";
@@ -9,6 +9,14 @@ import SearchBar from "@/components/SearchBar";
 type Note = { _id: string; title: string; content: string; tags?: string[] };
 
 export default function Dashboard() {
+  return (
+    <Suspense fallback={<div className="p-4">Loading…</div>}>
+      <DashboardContent />
+    </Suspense>
+  );
+}
+
+function DashboardContent() {
   const searchParams = useSearchParams();
   const [notes, setNotes] = useState<Note[]>([]);
   const [filteredNotes, setFilteredNotes] = useState<Note[]>([]);
@@ -91,7 +99,6 @@ export default function Dashboard() {
       setDeleteNote(null);
     } catch (err: unknown) {
       console.error("Error deleting note:", err);
-      // You might want to show an error toast here
     }
   };
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,9 +1,18 @@
 "use client";
 
+import { Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 
 export default function LoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginContent />
+    </Suspense>
+  );
+}
+
+function LoginContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [error, setError] = useState("");
@@ -28,7 +37,6 @@ export default function LoginPage() {
         throw new Error("Login failed");
       }
 
-      // Redirect to the originally requested page or dashboard
       const nextUrl = searchParams.get("next") || "/dashboard";
       router.push(nextUrl);
       router.refresh();


### PR DESCRIPTION
## Purpose
Fix Next.js build errors caused by `useSearchParams()` not being wrapped in Suspense boundaries. The user encountered prerender errors during build that prevented successful compilation of the login and dashboard pages.

## Code changes
- **Dashboard page**: Wrapped the main component in `Suspense` with a loading fallback and extracted the logic into a separate `DashboardContent` component
- **Login page**: Added `Suspense` wrapper around the login logic, extracted into `LoginContent` component with null fallback
- **Cleanup**: Removed unnecessary comments from both files
- **Imports**: Added `Suspense` import to both pages

This resolves the Next.js CSR bailout warnings and allows the application to build successfully while maintaining proper server-side rendering support.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e1a3be388c8d4fb99c6232f7a47eb711/pulse-haven)

👀 [Preview Link](https://e1a3be388c8d4fb99c6232f7a47eb711-pulse-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e1a3be388c8d4fb99c6232f7a47eb711</projectId>-->
<!--<branchName>pulse-haven</branchName>-->